### PR TITLE
[PPP-4182] Use of vulnerable component dom4j-1.6.1.jar  CVE-2018-1000632

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
     <castor-maven-plugin.version>2.1</castor-maven-plugin.version>
     <commons-lang3.version>3.0</commons-lang3.version>
     <commons-logging.version>1.1</commons-logging.version>
-    <dom4j.version>1.6.1</dom4j.version>
     <junit.version>4.3.1</junit.version>
     <pentaho-reporting.version>8.2.0.0-SNAPSHOT</pentaho-reporting.version>
     <license.licenseName>lgpl_v2_1</license.licenseName>
@@ -52,16 +51,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>${dom4j.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This is one of a series of PRs. See pentaho/maven-parent-poms#70 for the complete list and more details. **Do not merge until further notice!**

@graimundo